### PR TITLE
ADD: include socks dependency for socks proxying (Tor)

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -13,6 +13,8 @@ let net = global.net;
 let tls = global.tls;
 const TIMEOUT = 5000;
 
+const SocksClient = require('socks').SocksClient;
+
 const TlsSocketWrapper = require('./TlsSocketWrapper.js');
 const EventEmitter = require('events').EventEmitter;
 const util = require('./util');
@@ -76,6 +78,34 @@ class Client {
       return Promise.resolve();
     }
     this.status = 1;
+    if (this._options.proxy.port) {
+      this.conn = SocksClient.createConnection(this._options).then(info => {
+        console.log(`SOCKS connected to ${this._options.destination.host}:${this._options.destination.port}`);
+        let socket = info.socket;
+        socket.setTimeout(TIMEOUT);
+        socket.setEncoding('utf8');
+        socket.setKeepAlive(true, 0);
+        socket.setNoDelay(true);
+        socket.on('connect', () => {
+          socket.setTimeout(0);
+          this.onConnect();
+        });
+        socket.on('close', e => {
+          this.onClose(e);
+        });
+        socket.on('data', chunk => {
+          socket.setTimeout(0);
+          this.onRecv(chunk);
+        });
+        socket.on('error', e => {
+          this.onError(e);
+        });
+
+        return socket;
+      });
+
+      return this.conn;
+    }
     return this.connectSocket(this.conn, this.port, this.host);
   }
 
@@ -94,8 +124,15 @@ class Client {
     if (this.status === 0) {
       return;
     }
-    this.conn.end();
-    this.conn.destroy();
+    if (this._options.proxy.port) {
+      this.conn.then(socket => {
+        socket.end();
+        socket.destroy();
+      });
+    } else {
+      this.conn.end();
+      this.conn.destroy();
+    }
     this.status = 0;
   }
 
@@ -107,7 +144,14 @@ class Client {
       const id = ++this.id;
       const content = util.makeRequest(method, params, id);
       this.callback_message_queue[id] = util.createPromiseResult(resolve, reject);
-      this.conn.write(content + '\n');
+      if (this._options.proxy.port) {
+        this.conn.then(socket => {
+          socket.write(content + '\n');
+          socket.resume();
+        });
+      } else {
+        this.conn.write(content + '\n');
+      }
     });
   }
 
@@ -130,7 +174,14 @@ class Client {
       const content = '[' + contents.join(',') + ']';
       this.callback_message_queue[this.id] = util.createPromiseResultBatch(resolve, reject, arguments_far_calls);
       // callback will exist only for max id
-      this.conn.write(content + '\n');
+      if (this._options.proxy.port) {
+        this.conn.then(socket => {
+          socket.write(content + '\n');
+          socket.resume();
+        });
+      } else {
+        this.conn.write(content + '\n');
+      }
     });
   }
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "dependencies": {},
+  "dependencies": {
+    "socks": "git+https://github.com/chrisc93/socks.git#b4291e37528869a2b9259513476d636d9903a1c4"
+  },
   "devDependencies": {},
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adding a feature to get a socks proxy working for devices that are running a local socks server (Orbot for Android).

**Note**
I am using my personal fork of [socks](https://github.com/chrisc93/socks) which has a few minor changes to get the library working in BlueWallet. Changes include:

1. Using `const net = global.net` instead of requiring node's `net`
2. Removing the `this.prependOnceListener` routine in the `connect` function. react-native-tcp wasn't playing nicely with this, and removing it didn't seem to cause any unintended side effects.
3. Using my own personal [node-ip](https://github.com/chrisc93/node-ip) library which is modified to use `react-native-os`.

Ideally we'd port these changes to live under the BlueWallet organization in their respective repositories.