### PR TITLE
Improve Message Parser

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -9,26 +9,6 @@ const makeRequest = (exports.makeRequest = (method, params, id) => {
   });
 });
 
-const createRecuesiveParser = (exports.createRecuesiveParser = (max_depth, delimiter) => {
-  const MAX_DEPTH = max_depth;
-  const DELIMITER = delimiter;
-  const recursiveParser = (n, buffer, callback) => {
-    if (buffer.length === 0) {
-      return { code: 0, buffer: buffer };
-    }
-    if (n > MAX_DEPTH) {
-      return { code: 1, buffer: buffer };
-    }
-    const xs = buffer.split(DELIMITER);
-    if (xs.length === 1) {
-      return { code: 0, buffer: buffer };
-    }
-    callback(xs.shift(), n);
-    return recursiveParser(n + 1, xs.join(DELIMITER), callback);
-  };
-  return recursiveParser;
-});
-
 const createPromiseResult = (exports.createPromiseResult = (resolve, reject) => {
   return (err, result) => {
     if (err) reject(err);
@@ -51,18 +31,30 @@ const createPromiseResultBatch = (exports.createPromiseResultBatch = (resolve, r
 
 class MessageParser {
   constructor(callback) {
-    this.buffer = '';
+    this.parts = [];
+    this.partsLen = 0;
     this.callback = callback;
-    this.recursiveParser = createRecuesiveParser(20, '\n');
   }
   run(chunk) {
-    this.buffer += chunk;
+    let s = chunk;
+    if (this.partsLen > 0) {
+      this.parts.push(chunk);
+      s = this.parts.join('');
+      this.parts = [];
+      this.partsLen = 0;
+    }
+    let start = 0;
+    let n = 0;
     while (true) {
-      const res = this.recursiveParser(0, this.buffer, this.callback);
-      this.buffer = res.buffer;
-      if (res.code === 0) {
-        break;
-      }
+      const idx = s.indexOf('\n', start);
+      if (idx === -1) break;
+      this.callback(s.slice(start, idx), n++);
+      start = idx + 1;
+    }
+    if (start < s.length) {
+      const tail = start === 0 ? s : s.slice(start);
+      this.parts.push(tail);
+      this.partsLen += tail.length;
     }
   }
 }


### PR DESCRIPTION
Old parser used recursive `split('\n') + join('\n')` per frame and buffer += chunk per recv. Both quadratic in total bytes. On big history dumps (10k+ tx wallets) this stalls the JS thread on RN, freezing UI.

New parser scans with `indexOf('\n')` and slice in a flat loop.

Also drops the `MAX_DEPTH=20` cap that forced re-scans on chunks containing >20 frames.

Same observable behavior.

O(n²) → O(n)